### PR TITLE
Add event info and undread info to notifications

### DIFF
--- a/back/app/Http/Controllers/UserNotificationController.php
+++ b/back/app/Http/Controllers/UserNotificationController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Exceptions\Exceptions\FailActionOnModelException;
 use App\Models\UserNotification;
 use App\Services\UserNotificationService;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class UserNotificationController extends Controller
@@ -14,15 +13,22 @@ class UserNotificationController extends Controller
         protected readonly UserNotificationService $notificationService
     ) {}
 
-    public function index()
+    public function index(): array
     {
-        return Auth::user()->notificationsData()->paginate(5, [
+        $user = Auth::user();
+        $totalUnread = $user->userNotifications()->where('read', 0)->count();
+        $paginator = $user->notificationsData()->paginate(5, [
             'user_notifications.id',
             'user_notifications.user_id',
             'user_notifications.title',
             'user_notifications.description',
+            'user_notifications.event_id',
             'user_notification_user.read',
-        ]);
+        ])->toArray();
+
+        $paginator['totalUnread'] = $totalUnread;
+
+        return $paginator;
     }
 
     /**

--- a/back/app/Models/Event.php
+++ b/back/app/Models/Event.php
@@ -73,4 +73,9 @@ class Event extends Model implements OwnedModel
             'id'
         );
     }
+
+    public function notifications(): HasMany
+    {
+        return $this->hasMany(UserNotification::class, 'event_id', 'id');
+    }
 }

--- a/back/app/Models/UserNotification.php
+++ b/back/app/Models/UserNotification.php
@@ -41,6 +41,11 @@ class UserNotification extends Model
         return $this->belongsTo(User::class, 'change_by', 'id');
     }
 
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class, 'event_id', 'id');
+    }
+
     /**
      * @throws CannotImplementThisMethodException
      */

--- a/back/database/migrations/2024_02_26_103251_add_event_id_to_user_notifications_table.php
+++ b/back/database/migrations/2024_02_26_103251_add_event_id_to_user_notifications_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Event as EventModel;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_notifications', function (Blueprint $table) {
+            $table->foreignUuid('event_id')->nullable()->references('id')->on('events');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_notifications', function (Blueprint $table) {
+            $table->dropForeignIdFor(EventModel::class);
+            $table->dropColumn('event_id');
+        });
+    }
+};


### PR DESCRIPTION
 - add event_id to user_notifications table
 - now we know which notification belongs to which event
 - add number of total unread notifications to api response
 - now it is possible to know how many unread notifications a user has on one API request